### PR TITLE
validator: use proto Unmarshal instead of CodeGeneratorRequest

### DIFF
--- a/cmd/protoc-gen-gapic-validator/main.go
+++ b/cmd/protoc-gen-gapic-validator/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Fatal(err)
 	}
 	var req plugin.CodeGeneratorRequest
-	if err := req.Unmarshal(reqBytes); err != nil {
+	if err := proto.Unmarshal(reqBytes, &req); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
github.com/goalng/protobuf v1.4.0 removed `CodeGeneratorRequest.Unmarshal`, so this refactors to the `proto` version of the same method to allow for an upgrade.