### PR TITLE
conformance: improve verbose output & fix proto pkg

### DIFF
--- a/cmd/gapic-error-conformance/main.go
+++ b/cmd/gapic-error-conformance/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -25,7 +26,7 @@ import (
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/longrunning"
 	"google.golang.org/genproto/googleapis/rpc/status"
-	
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
@@ -62,18 +63,24 @@ func main() {
 	// run conformance evaluation
 	var failed bool
 	for _, s := range scenarios {
+		if verbose {
+			log.Printf("=== Scenario: %s ===", s.name)
+		}
 		// execute CodeGeneratorRequest with both plugins
 		vResp, pResp, err := gen(s.req)
 		if err != nil {
 			log.Fatal(err)
 		}
+		verr := vResp.GetError()
+		perr := pResp.GetError()
 		if verbose {
-			log.Println("validator:", vResp.GetError())
-			log.Println("plugin:   ", pResp.GetError())
+			log.Println("validator:", strings.TrimSpace(verr))
+			log.Println("plugin:   ", strings.TrimSpace(perr))
+			fmt.Println()
 		}
 
 		// validator & plugin response error messages
-		if diff := compare(vResp.GetError(), pResp.GetError()); diff != nil {
+		if diff := compare(verr, perr); diff != nil {
 			fmt.Println()
 			fmt.Println(s.name, diff)
 			failed = true
@@ -88,6 +95,7 @@ func main() {
 // gen executes the CodeGeneratorRequest with the gapic-config-validator
 // and the plugin named via the -plugin flag, and returns both responses.
 func gen(req *plugin.CodeGeneratorRequest) (vResp, pResp *plugin.CodeGeneratorResponse, err error) {
+	var stderr bytes.Buffer
 	vResp, err = validator.Validate(req)
 	if err != nil {
 		log.Fatal(err)
@@ -104,6 +112,10 @@ func gen(req *plugin.CodeGeneratorRequest) (vResp, pResp *plugin.CodeGeneratorRe
 		log.Fatal(err)
 	}
 
+	if verbose {
+		cmd.Stderr = &stderr
+	}
+
 	_, err = in.Write(reqData)
 	if err != nil {
 		log.Fatal(err)
@@ -113,6 +125,11 @@ func gen(req *plugin.CodeGeneratorRequest) (vResp, pResp *plugin.CodeGeneratorRe
 	resData, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if verbose && stderr.Len() > 0 {
+		log.Printf("plugin stderr: %s", string(stderr.Bytes()))
+		fmt.Println()
 	}
 
 	pResp = &plugin.CodeGeneratorResponse{}

--- a/cmd/gapic-error-conformance/main.go
+++ b/cmd/gapic-error-conformance/main.go
@@ -64,7 +64,7 @@ func main() {
 	var failed bool
 	for _, s := range scenarios {
 		if verbose {
-			log.Printf("=== Scenario: %s ===", s.name)
+			fmt.Printf("=== Scenario: %s ===\n", s.name)
 		}
 		// execute CodeGeneratorRequest with both plugins
 		vResp, pResp, err := gen(s.req)
@@ -74,8 +74,8 @@ func main() {
 		verr := vResp.GetError()
 		perr := pResp.GetError()
 		if verbose {
-			log.Println("validator:", strings.TrimSpace(verr))
-			log.Println("plugin:   ", strings.TrimSpace(perr))
+			fmt.Println("validator:", strings.TrimSpace(verr))
+			fmt.Println("plugin:   ", strings.TrimSpace(perr))
 			fmt.Println()
 		}
 
@@ -128,7 +128,7 @@ func gen(req *plugin.CodeGeneratorRequest) (vResp, pResp *plugin.CodeGeneratorRe
 	}
 
 	if verbose && stderr.Len() > 0 {
-		log.Printf("plugin stderr: %s", string(stderr.Bytes()))
+		fmt.Printf("plugin stderr: %s\n", string(stderr.Bytes()))
 		fmt.Println()
 	}
 

--- a/cmd/gapic-error-conformance/main.go
+++ b/cmd/gapic-error-conformance/main.go
@@ -309,7 +309,7 @@ func buildProto(fopts *descriptor.FileOptions, sopts *descriptor.ServiceOptions,
 	}
 	fopts.GoPackage = proto.String("foo.com/bar/v1;bar")
 
-	file := builder.NewFile("foo.proto").SetPackageName("foo").SetOptions(fopts)
+	file := builder.NewFile("foo.proto").SetPackageName("foo.v1").SetOptions(fopts)
 
 	// when ServiceOptions is nil, set to default valid value
 	if sopts == nil {


### PR DESCRIPTION
Log stderr of plugin process in `verbose` mode - Fixes #110 
Log scenario names in `verbose` mode - Fixes #111 

An example of the new `verbose` mode output (with fake stderr logging from the plugin):

```
$ gapic-error-conformance -plugin=protoc-gen-go_gapic -plugin_opts="go-gapic-package=github.com/foo/bar/apiv1;bar" -verbose
=== Scenario: missing default_host ===
plugin stderr: Hello, World!

validator: service "foo.FooService" is missing option google.api.default_host
plugin:    service "foo.FooService" is missing option google.api.default_host

=== Scenario: missing LRO response_type ===
validator: unable to resolve google.longrunning.operation_info.response_type value "Bad" in rpc "foo.FooService.CreateFoo"
plugin:    unable to resolve google.longrunning.operation_info.response_type value "Bad" in rpc "foo.FooService.CreateFoo"

=== Scenario: missing LRO operation_info ===
validator: rpc "foo.FooService.CreateFoo" returns google.longrunning.Operation but is missing option google.longrunning.operation_info
plugin:    rpc "foo.FooService.CreateFoo" returns google.longrunning.Operation but is missing option google.longrunning.operation_info

=== Scenario: unresolvable LRO response_type ===
validator: rpc "foo.FooService.CreateFoo" returns google.longrunning.Operation but is missing option google.longrunning.operation_info
plugin:    rpc "foo.FooService.CreateFoo" returns google.longrunning.Operation but is missing option google.longrunning.operation_info

=== Scenario: unresolvable LRO metadata_type ===
validator: unable to resolve google.longrunning.operation_info.metadata_type value "Bad" in rpc "foo.FooService.CreateFoo"
plugin:    unable to resolve google.longrunning.operation_info.metadata_type value "Bad" in rpc "foo.FooService.CreateFoo"

=== Scenario: bad method_signature field ===
validator: field "bad" listed in rpc "foo.FooService.CreateFoo" method signature entry ("a,bad") does not exist in "foo.Foo"
plugin:    

=== Scenario: repeated nested field component in method_signature ===
validator: rpc "foo.FooService.CreateFoo" method signature entry field "bar.c" cannot be a field within a repeated field
plugin:    

=== Scenario: unresolvable Message for resource_reference ===
validator: resource_reference.(child_)type for field "foo.Foo.a" must be {service_name}/{resource_type_kind}
plugin:    

=== Scenario: resource_reference to unannotated field ===
validator: resource_reference.(child_)type for field "foo.Foo.a" must be {service_name}/{resource_type_kind}
plugin:
```

Please review this output @xiaozhenliu-gg5 and give LGTM is sufficient. If you'd like more info/diff formatting, please say so!

Also, I fixed the package issue for #112. I tested it with gapic-generator-typescript already so I _think_ it will work.